### PR TITLE
fix group relationship issue where key-not-found exception can arise

### DIFF
--- a/src/Parser/XmlParser.cs
+++ b/src/Parser/XmlParser.cs
@@ -84,10 +84,9 @@ namespace Dox2Word.Parser
                 {
                     foreach (var include in fileDef.Includes.Where(x => x.IsLocal == DoxBool.Yes && x.RefId != null))
                     {
-                        if (fileIdToOwningGroup.ContainsKey(fileDef.Id) && fileIdToOwningGroup.ContainsKey(include.RefId!))
+                        if (fileIdToOwningGroup.TryGetValue(fileDef.Id, out var includingGroup) &&
+                            fileIdToOwningGroup.TryGetValue(include.RefId!, out var includedGroup))
                         {
-                            var includingGroup = fileIdToOwningGroup[fileDef.Id];
-                            var includedGroup = fileIdToOwningGroup[include.RefId!];
                             if (includingGroup != includedGroup)
                             {
                                 if (!includingGroup.IncludedGroups.Contains(includedGroup))

--- a/src/Parser/XmlParser.cs
+++ b/src/Parser/XmlParser.cs
@@ -84,17 +84,20 @@ namespace Dox2Word.Parser
                 {
                     foreach (var include in fileDef.Includes.Where(x => x.IsLocal == DoxBool.Yes && x.RefId != null))
                     {
-                        var includingGroup = fileIdToOwningGroup[fileDef.Id];
-                        var includedGroup = fileIdToOwningGroup[include.RefId!];
-                        if (includingGroup != includedGroup)
+                        if (fileIdToOwningGroup.ContainsKey(fileDef.Id) && fileIdToOwningGroup.ContainsKey(include.RefId!))
                         {
-                            if (!includingGroup.IncludedGroups.Contains(includedGroup))
+                            var includingGroup = fileIdToOwningGroup[fileDef.Id];
+                            var includedGroup = fileIdToOwningGroup[include.RefId!];
+                            if (includingGroup != includedGroup)
                             {
-                                includingGroup.IncludedGroups.Add(includedGroup);
-                            }
-                            if (!includedGroup.IncludingGroups.Contains(includingGroup))
-                            {
-                                includedGroup.IncludingGroups.Add(includingGroup);
+                                if (!includingGroup.IncludedGroups.Contains(includedGroup))
+                                {
+                                    includingGroup.IncludedGroups.Add(includedGroup);
+                                }
+                                if (!includedGroup.IncludingGroups.Contains(includingGroup))
+                                {
+                                    includedGroup.IncludingGroups.Add(includingGroup);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The change checks if the key is available before accessing it. Since in some cases (different doxygen usage in code) the list might be empty (or not contain all keys). This simply prevents an exception and allows the parser to continue.

**Checklist**

Thanks for contributing! Before we start, there are a few things we need to check:

1. This Pull Request has a corresponding Issue. - no
2. You've discussed your intention to work on this feature/bug fix. - no
3. This feature branch is based on develop (**not** master). The bar above should say "base: develop". - yes

Thanks!