### PR TITLE
Use last instead of first paragraph before <MODULE>

### DIFF
--- a/src/Generator/WordGenerator.cs
+++ b/src/Generator/WordGenerator.cs
@@ -71,7 +71,7 @@ namespace Dox2Word.Generator
                 if (markerParagraph == null)
                     throw new GeneratorException($"Could not find placeholder text '{Placeholder}'");
 
-                var headingBefore = markerParagraph.ElementsBefore().OfType<Paragraph>().FirstOrDefault();
+                var headingBefore = markerParagraph.ElementsBefore().OfType<Paragraph>().LastOrDefault();
                 int headingLevel = 2;
                 if (headingBefore?.ParagraphProperties?.ParagraphStyleId?.Val?.Value is { } styleId && styleId.StartsWith("Heading"))
                 {


### PR DESCRIPTION
To find the header level the first paragraph before <MODULES> is used. This might lead to a wrong paragraph used, depending on the used template. It might be better to use the last one before <MODULES> to get the right level.
Example template:

```
<Title>          <--- first paragraph
<Header1>
  <Header2>
<Header1>
  <Header2>      <--- last paragraph
    "<MODULES>"
```

**Checklist**

Thanks for contributing! Before we start, there are a few things we need to check:

1. This Pull Request has a corresponding Issue. - no
2. You've discussed your intention to work on this feature/bug fix. - no
3. This feature branch is based on develop (**not** master). The bar above should say "base: develop". - yes

Thanks!